### PR TITLE
npmには公開していないので`"private": true`を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
     "url": "git@github.com:frontainer/frontplate.git"
   },
   "author": "frontainer",
-  "license": "MIT"
+  "license": "MIT",
+  "private": true
 }


### PR DESCRIPTION
現在npm上でfrontplateを公開していないようですが、もしnpmで公開する予定がなければ、公開していないことを示すのと、誤って公開するのを防ぐために`"private": true`を付けたほうが良いと思います。

## 例

- https://github.com/google/web-starter-kit/blob/master/package.json#L36
- https://github.com/kubosho/nozomi/blob/master/package.json#L20