### PR TITLE
productionの際にinline mapが出力されないようにした。

### DIFF
--- a/gulp/script.js
+++ b/gulp/script.js
@@ -19,6 +19,9 @@ const FILE_EXT = /\.(ts|js)$/;
  */
 gulp.task('_setEntries', () => {
     conf = require('../webpack.config.js');
+    if (config.IS_PRODUCTION) {
+        delete conf.devtool;
+    }
     return gulp.src(config.path.js.src)
         .pipe(through.obj(function(file,charset,callback) {
             conf.entry = conf.entry || {};


### PR DESCRIPTION
productionタスクで出力されたjavascriptにinline mapが含まれていたので、含めないようにしました。