### PR TITLE
It is better to add charset at-rule to style.css

### DIFF
--- a/src/pc/sass/style.scss
+++ b/src/pc/sass/style.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 @import 'setting';
 
 //@import 'base/sanitize';


### PR DESCRIPTION
It looks better to add `@charset "utf-8"` because some unicode characters like icon-font can cause misconversions.