### PR TITLE
Add '-moz-os-font-smoothing' to fix Firefox issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Frontplate",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "フロントエンド開発の効率をあげるフルスタックテンプレート",
   "dependencies": {},
   "devDependencies": {},

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -10,6 +10,7 @@ body {
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   -webkit-font-smoothing: $font-smoothing;
+  -moz-osx-font-smoothing: grayscale;
   font-smoothing: $font-smoothing;
   text-rendering: $text-rendering;
   font-size: $base-font-size;


### PR DESCRIPTION
I suggest to add this property. Because it will fix the unnecessary Firefox behavior: if the text colored with white or light-gray, Firefox changes the font-weight bolder. That is for accessibility but unwanted in most case.