### PR TITLE
Fix typo at index.ejs

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -12,7 +12,7 @@
   <title>PAGE TITLE</title>
   <% include view/_header %>
 </head>
-<body>s
+<body>
 <script src="assets/js/app.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
- Remove the unnecessary character "s"