### PR TITLE
Update .eslintrc to require trailing commas

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "comma-dangle": ["error", "always-multiline"],
+    "comma-dangle": ["warn", "always-multiline"],
     "no-console": 1,
     "eol-last": 0,
     "block-scoped-var": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,13 @@
     "sourceType": "module"
   },
   "rules": {
-    "comma-dangle": ["warn", "always-multiline"],
+    "comma-dangle": ["warn", {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never",
+    }],
     "no-console": 1,
     "eol-last": 0,
     "block-scoped-var": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "comma-dangle": [1, "never"],
+    "comma-dangle": ["error", "always-multiline"],
     "no-console": 1,
     "eol-last": 0,
     "block-scoped-var": 0,


### PR DESCRIPTION
This will let developers to always put trailing commas onto the multiline array or object definitions.

ref. https://eslint.org/docs/rules/comma-dangle

Trailing commas will reduce the diff clutters such as:
```diff
 var foo = {
-    bar: "baz",
-    qux: "quux"
+    bar: "baz"
 };
```
and makes it like:
```diff
 var foo = {
     bar: "baz",
-    qux: "quux",
 };
```